### PR TITLE
Add JSON payload support for encrypt endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,12 @@ Request body:
 {
   "plaintext": "<data>",
   "plaintext_encoding": "base64", // or "utf-8"
+  "json": { "hello": "world" }, // optional structured payload
   "sign": true
 }
 ```
 
-`plaintext` is interpreted as Base64 unless `plaintext_encoding` is `"utf-8"`. When `sign` is true, the service must be configured with a signing private key.
+Provide either `plaintext` (interpreted as Base64 unless `plaintext_encoding` is `"utf-8"`) **or** a structured JSON value via the `json` field. When `sign` is true, the service must be configured with a signing private key.
 
 Response:
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,75 @@
+package server
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+func TestResolveEncryptPayloadJSON(t *testing.T) {
+	req := &encryptRequest{JSON: []byte("{\"foo\":\"bar\"}")}
+	got, err := resolveEncryptPayload(req)
+	if err != nil {
+		t.Fatalf("resolveEncryptPayload() error = %v", err)
+	}
+	want := []byte("{\"foo\":\"bar\"}")
+	if string(got) != string(want) {
+		t.Fatalf("expected %s, got %s", want, got)
+	}
+}
+
+func TestResolveEncryptPayloadJSONWhitespace(t *testing.T) {
+	req := &encryptRequest{JSON: []byte("  [1,2,3]  ")}
+	got, err := resolveEncryptPayload(req)
+	if err != nil {
+		t.Fatalf("resolveEncryptPayload() error = %v", err)
+	}
+	want := []byte("[1,2,3]")
+	if string(got) != string(want) {
+		t.Fatalf("expected %s, got %s", want, got)
+	}
+}
+
+func TestResolveEncryptPayloadPlaintext(t *testing.T) {
+	value := base64.StdEncoding.EncodeToString([]byte("secret"))
+	req := &encryptRequest{Plaintext: value}
+	got, err := resolveEncryptPayload(req)
+	if err != nil {
+		t.Fatalf("resolveEncryptPayload() error = %v", err)
+	}
+	want := []byte("secret")
+	if string(got) != string(want) {
+		t.Fatalf("expected %s, got %s", want, got)
+	}
+}
+
+func TestResolveEncryptPayloadErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *encryptRequest
+	}{
+		{"missing", &encryptRequest{}},
+		{"both", &encryptRequest{Plaintext: "test", JSON: []byte("{}")}},
+		{"emptyJSON", &encryptRequest{JSON: []byte("   ")}},
+		{"invalidEncoding", &encryptRequest{Plaintext: "test", PlaintextEncoding: "unknown"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := resolveEncryptPayload(tc.req)
+			if err == nil {
+				t.Fatalf("expected error for %s", tc.name)
+			}
+		})
+	}
+}
+
+func TestResolveEncryptPayloadInvalidJSON(t *testing.T) {
+	req := &encryptRequest{JSON: []byte("  {invalid}  ")}
+	_, err := resolveEncryptPayload(req)
+	if err == nil {
+		t.Fatalf("expected error for invalid JSON")
+	}
+	if err.Error() != "json payload must be valid JSON" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- allow the /encrypt endpoint to accept structured JSON payloads via a new request field
- validate mutually exclusive plaintext/json inputs and reject empty or invalid JSON
- document the new request shape and cover payload selection logic with unit tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d645d50f0c8328b307a5269170a946